### PR TITLE
Provide an `AsyncGenerator` instead of a callback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,11 @@ pip install aiobrultech-serial
 
 ```python
 from aiobrultech_serial import connect
-from siobrultech_protocols.gem.packets import Packet
 
 
-async def handler(packet: Packet) -> None:
-    print("{}".format(packet))
-
-connect(handler, port)
+async with connect("/dev/ttyUSB0") as connection:
+    async for packet in connection.packets():
+        print(f"{packet}")
 ```
 
 Look at [`scripts/dump.py`](https://github.com/sdwilsh/aiobrultech-serial/blob/main/scripts/dump.py)

--- a/aiobrultech_serial/__init__.py
+++ b/aiobrultech_serial/__init__.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import asyncio
 import functools
 import logging
-from asyncio.queues import Queue
 from asyncio.tasks import Task
-from typing import Any, Awaitable, Callable
+from typing import Any, AsyncGenerator
 
 import serial_asyncio
 from siobrultech_protocols.gem.packets import Packet
@@ -15,63 +14,58 @@ logger = logging.getLogger(__name__)
 
 
 class Connection(object):
-    def __init__(
-        self,
-        queue: Queue,
-        consumer_task: Task[None],
-        producer_task: Task[tuple[serial_asyncio.SerialTransport, Any]],
-    ):
-        self._consumer_task = consumer_task
-        self._queue = queue
-        self._producer_task = producer_task
+    def __init__(self, port: str, baudrate: int = 115200, **kwargs):
+        self._closed_future = asyncio.Future()
+        self._packets = asyncio.Queue()
+        self._producer_task: Task[
+            tuple[serial_asyncio.SerialTransport, Any]
+        ] = asyncio.create_task(
+            serial_asyncio.create_serial_connection(
+                asyncio.get_event_loop(),
+                functools.partial(PacketProtocol, queue=self._packets),
+                port,
+                baudrate=baudrate,
+                **kwargs,
+            ),
+            name=f"{__name__}:serial-connection",
+        )
+
+    async def packets(self) -> AsyncGenerator[Packet, None]:
+        transport, _ = await self._producer_task
+        while not transport.is_closing() and not self._closed_future.done():
+            task: Task[Packet] = asyncio.create_task(
+                self._packets.get(), name=f"{__name__}:wait-for-packet"
+            )
+            try:
+                # Wait until either:
+                # 1) a second has passed
+                # 2) a packet is processed
+                done, _ = await asyncio.wait(
+                    (asyncio.create_task(asyncio.sleep(1)), task),
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+            except asyncio.CancelledError:
+                logger.debug("queue generator is getting canceled")
+                task.cancel()
+                raise
+            if task in done:
+                self._packets.task_done()
+                yield task.result()
+            else:
+                # Try again if our loop condition is good still.
+                task.cancel()
 
     async def close(self) -> None:
-        transport, _ = await self._producer_task
-        transport.close()
-        await self._queue.join()
-        self._consumer_task.cancel()
+        if not self._closed_future.done():
+            self._closed_future.set_result(True)
+            transport, _ = await self._producer_task
+            transport.close()
 
     async def __aenter__(self) -> Connection:
         return self
 
     async def __aexit__(self, exc_type, exc, exc_traceback):
-        if exc is not None:
-            await self.close()
+        await self.close()
 
 
-def connect(
-    packet_handler: Callable[[Packet], Awaitable[None]],
-    port: str,
-    baudrate: int = 115200,
-    **kwargs
-) -> Connection:
-    async def consumer(queue: Queue) -> None:
-        try:
-            while True:
-                packet: Packet = await queue.get()
-                try:
-                    await packet_handler(packet)
-                except Exception as exc:
-                    logger.exception("Exception while calling packet handler!", exc)
-                queue.task_done()
-        except asyncio.CancelledError:
-            logger.debug("queue consumer is getting canceled")
-            raise
-
-    loop = asyncio.get_event_loop()
-    queue = asyncio.Queue()
-
-    consumer_task = asyncio.create_task(
-        consumer(queue), name="consumer:{}".format(port)
-    )
-    producer_task = asyncio.create_task(
-        serial_asyncio.create_serial_connection(
-            loop,
-            functools.partial(PacketProtocol, queue=queue),
-            port,
-            baudrate=baudrate,
-            **kwargs
-        )
-    )
-
-    return Connection(queue, consumer_task, producer_task)
+connect = Connection

--- a/scripts/dump.py
+++ b/scripts/dump.py
@@ -2,8 +2,6 @@ import argparse
 import asyncio
 import logging
 
-from siobrultech_protocols.gem.packets import Packet
-
 from aiobrultech_serial import connect
 
 
@@ -20,10 +18,9 @@ def init_argparse() -> argparse.ArgumentParser:
 
 
 async def main(port: str) -> None:
-    async def handler(packet: Packet) -> None:
-        print("{}".format(packet))
-
-    connect(handler, port)
+    async with connect(port) as connection:
+        async for packet in connection.packets():
+            print(f"{packet}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is simpler to use, and makes the client code very easy to read.  A
future implementation could provide a callback wrapper if someone
desired.