### PR TITLE
Update siobrultech-protocols to v0.2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ packages = find:
 install_requires = 
 	pyserial >= 3.5
 	pyserial-asyncio == 0.5
-	siobrultech-protocols == 0.1.1
+	siobrultech-protocols == 0.2.0
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
This fixes the typing of `Packet.polarized_watt_seconds`